### PR TITLE
chore!: update custom network properties key

### DIFF
--- a/chart/templates/uds-package-minio.yaml
+++ b/chart/templates/uds-package-minio.yaml
@@ -86,7 +86,7 @@ spec:
 
 
       # Custom rules for unanticipated scenarios
-      {{- range .Values.custom }}
+      {{- range .Values.additionalNetworkAllow }}
       - direction: {{ .direction }}
         selector:
           {{ .selector | toYaml | nindent 10 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,4 +36,4 @@ apps: []
 mcImage: ""
 mcShell: ""
 
-custom: []
+additionalNetworkAllow: []


### PR DESCRIPTION
## Description

- Updating all instances of custom: [] to additionalNetworkAllow: []

> [!CAUTION]
> **BREAKING CHANGE** `custom` has changed to `additionalNetworkAllow`

## Related Issue

Fixes #
<!-- or -->
Relates to #
https://github.com/orgs/defenseunicorns/projects/118/views/12?pane=issue&itemId=87152090&issue=defenseunicorns%7Cuds-package-maintenance%7C5
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-gitlab/blob/main/CONTRIBUTING.md#developer-workflow) followed
