### PR TITLE
fix: remediate broken monitoring by switching to pod monitor

### DIFF
--- a/chart/templates/uds-package-minio.yaml
+++ b/chart/templates/uds-package-minio.yaml
@@ -10,7 +10,8 @@ spec:
   monitor: 
     - selector:
         v1.min.io/tenant: {{ .Values.name }}
-      portName: http-minio
+      portName: minio-port
+      kind: PodMonitor
       targetPort: 9000
       description: "Metrics"
       path: /minio/v2/metrics/cluster


### PR DESCRIPTION
## Description

Fixes broken monitoring for minio due to labels no longer being present on the service by switching from service monitor to pod monitor.

VIsual Proof:
![image](https://github.com/user-attachments/assets/10089516-b2e9-4d72-abfa-31ea0b06fdd9)


## Related Issue

Fixes #
https://github.com/defenseunicorns/uds-package-minio-operator/issues/62

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-minio-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
