### PR TITLE
fix: keep minio secrets from rotating on upgrades

### DIFF
--- a/chart/templates/config-secret.yaml
+++ b/chart/templates/config-secret.yaml
@@ -1,8 +1,21 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+{{- $existing := lookup "v1" "Secret" "minio" (printf "%s-creds" .Values.name) }}
 
-{{- $password := .Values.rootPassword | default (randAlphaNum 32) }}
 {{- $user := .Values.rootUser | default "minio" }}
+{{- if $existing }}
+  {{- $existingUser := index $existing.data "rootUser" }}
+  {{- if $existingUser }}{{- $user = b64dec $existingUser }}{{- end }}
+{{- end }}
+
+{{- $password := randAlphaNum 32 }}
+{{- if .Values.rootPassword }}
+  {{- $password = .Values.rootPassword }}
+{{- end }}
+{{- if $existing }}
+  {{- $existingPass := index $existing.data "rootPassword" }}
+  {{- if $existingPass }}{{- $password = b64dec $existingPass }}{{- end }}
+{{- end }}
 
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
## Description

- Add templating logic to keep secret from rotating on upgrades

## Related Issue

Fixes #77 
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-minio-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
