### PR TITLE
fix: verify-test conditional

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,10 +66,10 @@ jobs:
       - name: Check validate result
         run: |
           echo "validate result: ${{ needs.validate.result }}"
-  
+
           if [ "${{ needs.validate.result }}" != "success" ]; then
             echo "One or more tests failed."
             exit 1
           fi
-  
+
           echo "All tests passed successfully!"


### PR DESCRIPTION
- always run verify test and fail if not successful, where previously this would mark failures as `skipped`