### PR TITLE
feat: retag registry1 latest

### DIFF
--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -35,7 +35,7 @@ jobs:
           # - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
           #   destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio-client
           #   sbom_package: mc
-          - source: registry1.dso.mil/ironbank/opensource/minio/minio:RELEASE.2025-10-15T17-29-55Z
+          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
             destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio
             sbom_package: minio
 
@@ -60,42 +60,42 @@ jobs:
       - name: Get version from Chainguard image SBOM
         id: chainguard_apk_version
         run: |
-          CHAINGUARD_APK_TAG=$(uds zarf tools sbom scan ${{ matrix.image.source }} -o spdx-json 2>/dev/null | \
+          CHAINGUARD_APK_TAG=$(uds zarf tools sbom scan ${{ matrix.image.source }} -o spdx-json | \
             jq -r '.packages[] | select(.name == "${{ matrix.image.sbom_package }}" and .supplier == "Person: wolfi") | .versionInfo')
           echo "SBOM Wolfi APK version: ${CHAINGUARD_APK_TAG}"
           echo "chainguard_apk_tag=${CHAINGUARD_APK_TAG}" >> "$GITHUB_OUTPUT"
 
-      # - name: Get latest tag from destination image
-      #   id: uds_package_image_tag
-      #   run: |
-      #     DESTINATION="${{ matrix.image.destination }}"
-      #     UDS_PACKAGE_IMAGE_TAG=$(uds zarf tools registry ls ${DESTINATION} 2>/dev/null | grep -v "ERR\|GET\|NAME_UNKNOWN" | sort -V | tail -n 1)
-      #     echo "Latest destination tag: ${UDS_PACKAGE_IMAGE_TAG}"
-      #     echo "uds_package_image_tag=${UDS_PACKAGE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+      - name: Get latest tag from destination image
+        id: uds_package_image_tag
+        run: |
+          DESTINATION="${{ matrix.image.destination }}"
+          UDS_PACKAGE_IMAGE_TAG=$(uds zarf tools registry ls ${DESTINATION} 2>/dev/null | grep -v "ERR\|GET\|NAME_UNKNOWN" | sort -V | tail -n 1)
+          echo "Latest destination tag: ${UDS_PACKAGE_IMAGE_TAG}"
+          echo "uds_package_image_tag=${UDS_PACKAGE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 
-      # - name: Check digest and retag if needed
-      #   run: |
-      #     SOURCE="${{ matrix.image.source }}"
-      #     DESTINATION="${{ matrix.image.destination }}"
-      #     CHAINGUARD_APK_TAG="${{ steps.chainguard_apk_version.outputs.chainguard_apk_tag }}"
-      #     UDS_PACKAGE_IMAGE_TAG="${{ steps.uds_package_image_tag.outputs.uds_package_image_tag }}"
+      - name: Check digest and retag if needed
+        run: |
+          SOURCE="${{ matrix.image.source }}"
+          DESTINATION="${{ matrix.image.destination }}"
+          CHAINGUARD_APK_TAG="${{ steps.chainguard_apk_version.outputs.chainguard_apk_tag }}"
+          UDS_PACKAGE_IMAGE_TAG="${{ steps.uds_package_image_tag.outputs.uds_package_image_tag }}"
 
-      #     if [ "${CHAINGUARD_APK_TAG}" = "${UDS_PACKAGE_IMAGE_TAG}" ]; then
-      #       SOURCE_DIGEST=$(uds zarf tools registry digest ${SOURCE})
-      #       echo "Source digest: ${SOURCE_DIGEST}"
+          if [ "${CHAINGUARD_APK_TAG}" = "${UDS_PACKAGE_IMAGE_TAG}" ]; then
+            SOURCE_DIGEST=$(uds zarf tools registry digest ${SOURCE})
+            echo "Source digest: ${SOURCE_DIGEST}"
 
-      #       DESTINATION_DIGEST=$(uds zarf tools registry digest ${DESTINATION}:${UDS_PACKAGE_IMAGE_TAG})
-      #       echo "Destination digest: ${DESTINATION_DIGEST}"
+            DESTINATION_DIGEST=$(uds zarf tools registry digest ${DESTINATION}:${UDS_PACKAGE_IMAGE_TAG})
+            echo "Destination digest: ${DESTINATION_DIGEST}"
 
-      #       if [ "${SOURCE_DIGEST}" = "${DESTINATION_DIGEST}" ]; then
-      #         echo "Tag ${CHAINGUARD_APK_TAG} exists with matching digest, no change needed"
-      #       else
-      #         echo "Tag ${CHAINGUARD_APK_TAG} exists with new digest, repushing image"
-      #         uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
-      #         echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
-      #       fi
-      #     else
-      #       echo "New Chainguard APK version ${CHAINGUARD_APK_TAG} detected, copying image"
-      #       uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
-      #       echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
-      #     fi
+            if [ "${SOURCE_DIGEST}" = "${DESTINATION_DIGEST}" ]; then
+              echo "Tag ${CHAINGUARD_APK_TAG} exists with matching digest, no change needed"
+            else
+              echo "Tag ${CHAINGUARD_APK_TAG} exists with new digest, repushing image"
+              uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
+              echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
+            fi
+          else
+            echo "New Chainguard APK version ${CHAINGUARD_APK_TAG} detected, copying image"
+            uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
+            echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
+          fi

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -9,8 +9,12 @@ name: Retag Minio Images
       # CHAINGUARD_APK_TAG != uds_package_image_tag → copy chainguard:latest/retag and push
 
 on:
+  push:
+    branches:
+      - retag-registry1-latest  
   schedule:
     - cron: '0 14 * * *' # daily at 8 AM Central
+  workflow_dispatch: # manual trigger for testing
 
 jobs:
   retag:
@@ -21,11 +25,17 @@ jobs:
     strategy:
       matrix:
         image:
-          - source: cgr.dev/chainguard/minio-client:latest
-            destination: ghcr.io/uds-packages/minio-operator/container/chainguard-minio-client
+          # - source: cgr.dev/chainguard/minio-client:latest
+          #   destination: ghcr.io/uds-packages/minio-operator/container/chainguard-minio-client
+          #   sbom_package: mc
+          # - source: cgr.dev/chainguard/minio:latest
+          #   destination: ghcr.io/uds-packages/minio-operator/container/chainguard-minio
+          #   sbom_package: minio
+          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
+            destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio-client
             sbom_package: mc
-          - source: cgr.dev/chainguard/minio:latest
-            destination: ghcr.io/uds-packages/minio-operator/container/chainguard-minio
+          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio:latest
+            destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio
             sbom_package: minio
 
     steps:
@@ -35,10 +45,12 @@ jobs:
           # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
           version: v0.30.0
 
-      - name: GHCR Login
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "${{ env.GH_TOKEN }}" | uds zarf tools registry login -u "dummy" --password-stdin ghcr.io
+      - name: Environment setup
+        run: |
+            uds run actions:setup-environment \
+            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
+            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
+            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
         shell: bash
 
       - name: Get version from Chainguard image SBOM

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -32,9 +32,9 @@ jobs:
           # - source: cgr.dev/chainguard/minio:latest
           #   destination: ghcr.io/uds-packages/minio-operator/container/chainguard-minio
           #   sbom_package: minio
-          # - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
-          #   destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio-client
-          #   sbom_package: mc
+          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
+            destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio-client
+            sbom_package: mc
           - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
             destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio
             sbom_package: minio
@@ -57,53 +57,53 @@ jobs:
         run: |
           docker pull registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
 
-      # - name: Environment setup
-      #   run: |
-      #       uds run actions:setup-environment \
-      #       --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
-      #       --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
-      #       --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-      #   shell: bash
+      - name: Environment setup
+        run: |
+            uds run actions:setup-environment \
+            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
+            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
+            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+        shell: bash
 
-      # - name: Get version from Chainguard image SBOM
-      #   id: chainguard_apk_version
-      #   run: |
-      #     CHAINGUARD_APK_TAG=$(uds zarf tools sbom scan ${{ matrix.image.source }} -o spdx-json | \
-      #       jq -r '.packages[] | select(.name == "${{ matrix.image.sbom_package }}" and .supplier == "Person: wolfi") | .versionInfo')
-      #     echo "SBOM Wolfi APK version: ${CHAINGUARD_APK_TAG}"
-      #     echo "chainguard_apk_tag=${CHAINGUARD_APK_TAG}" >> "$GITHUB_OUTPUT"
+      - name: Get version from Chainguard image SBOM
+        id: chainguard_apk_version
+        run: |
+          CHAINGUARD_APK_TAG=$(uds zarf tools sbom scan ${{ matrix.image.source }} -o spdx-json | \
+            jq -r '.packages[] | select(.name == "${{ matrix.image.sbom_package }}" and .supplier == "Person: wolfi") | .versionInfo')
+          echo "SBOM Wolfi APK version: ${CHAINGUARD_APK_TAG}"
+          echo "chainguard_apk_tag=${CHAINGUARD_APK_TAG}" >> "$GITHUB_OUTPUT"
 
-      # - name: Get latest tag from destination image
-      #   id: uds_package_image_tag
-      #   run: |
-      #     DESTINATION="${{ matrix.image.destination }}"
-      #     UDS_PACKAGE_IMAGE_TAG=$(uds zarf tools registry ls ${DESTINATION} 2>/dev/null | grep -v "ERR\|GET\|NAME_UNKNOWN" | sort -V | tail -n 1)
-      #     echo "Latest destination tag: ${UDS_PACKAGE_IMAGE_TAG}"
-      #     echo "uds_package_image_tag=${UDS_PACKAGE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+      - name: Get latest tag from destination image
+        id: uds_package_image_tag
+        run: |
+          DESTINATION="${{ matrix.image.destination }}"
+          UDS_PACKAGE_IMAGE_TAG=$(uds zarf tools registry ls ${DESTINATION} 2>/dev/null | grep -v "ERR\|GET\|NAME_UNKNOWN" | sort -V | tail -n 1)
+          echo "Latest destination tag: ${UDS_PACKAGE_IMAGE_TAG}"
+          echo "uds_package_image_tag=${UDS_PACKAGE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 
-      # - name: Check digest and retag if needed
-      #   run: |
-      #     SOURCE="${{ matrix.image.source }}"
-      #     DESTINATION="${{ matrix.image.destination }}"
-      #     CHAINGUARD_APK_TAG="${{ steps.chainguard_apk_version.outputs.chainguard_apk_tag }}"
-      #     UDS_PACKAGE_IMAGE_TAG="${{ steps.uds_package_image_tag.outputs.uds_package_image_tag }}"
+      - name: Check digest and retag if needed
+        run: |
+          SOURCE="${{ matrix.image.source }}"
+          DESTINATION="${{ matrix.image.destination }}"
+          CHAINGUARD_APK_TAG="${{ steps.chainguard_apk_version.outputs.chainguard_apk_tag }}"
+          UDS_PACKAGE_IMAGE_TAG="${{ steps.uds_package_image_tag.outputs.uds_package_image_tag }}"
 
-      #     if [ "${CHAINGUARD_APK_TAG}" = "${UDS_PACKAGE_IMAGE_TAG}" ]; then
-      #       SOURCE_DIGEST=$(uds zarf tools registry digest ${SOURCE})
-      #       echo "Source digest: ${SOURCE_DIGEST}"
+          if [ "${CHAINGUARD_APK_TAG}" = "${UDS_PACKAGE_IMAGE_TAG}" ]; then
+            SOURCE_DIGEST=$(uds zarf tools registry digest ${SOURCE})
+            echo "Source digest: ${SOURCE_DIGEST}"
 
-      #       DESTINATION_DIGEST=$(uds zarf tools registry digest ${DESTINATION}:${UDS_PACKAGE_IMAGE_TAG})
-      #       echo "Destination digest: ${DESTINATION_DIGEST}"
+            DESTINATION_DIGEST=$(uds zarf tools registry digest ${DESTINATION}:${UDS_PACKAGE_IMAGE_TAG})
+            echo "Destination digest: ${DESTINATION_DIGEST}"
 
-      #       if [ "${SOURCE_DIGEST}" = "${DESTINATION_DIGEST}" ]; then
-      #         echo "Tag ${CHAINGUARD_APK_TAG} exists with matching digest, no change needed"
-      #       else
-      #         echo "Tag ${CHAINGUARD_APK_TAG} exists with new digest, repushing image"
-      #         uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
-      #         echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
-      #       fi
-      #     else
-      #       echo "New Chainguard APK version ${CHAINGUARD_APK_TAG} detected, copying image"
-      #       uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
-      #       echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
-      #     fi
+            if [ "${SOURCE_DIGEST}" = "${DESTINATION_DIGEST}" ]; then
+              echo "Tag ${CHAINGUARD_APK_TAG} exists with matching digest, no change needed"
+            else
+              echo "Tag ${CHAINGUARD_APK_TAG} exists with new digest, repushing image"
+              uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
+              echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
+            fi
+          else
+            echo "New Chainguard APK version ${CHAINGUARD_APK_TAG} detected, copying image"
+            uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
+            echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
+          fi

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -49,53 +49,61 @@ jobs:
           # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
           version: v0.30.0
 
-      - name: Environment setup
+      - name: Login to registry1
         run: |
-            uds run actions:setup-environment \
-            --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
-            --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
-            --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
-        shell: bash
+          echo "${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" | docker login -u "${{ secrets.IRON_BANK_ROBOT_USERNAME }}" --password-stdin registry1.dso.mil
 
-      - name: Get version from Chainguard image SBOM
-        id: chainguard_apk_version
+      - name: Test docker pull
         run: |
-          CHAINGUARD_APK_TAG=$(uds zarf tools sbom scan ${{ matrix.image.source }} -o spdx-json | \
-            jq -r '.packages[] | select(.name == "${{ matrix.image.sbom_package }}" and .supplier == "Person: wolfi") | .versionInfo')
-          echo "SBOM Wolfi APK version: ${CHAINGUARD_APK_TAG}"
-          echo "chainguard_apk_tag=${CHAINGUARD_APK_TAG}" >> "$GITHUB_OUTPUT"
+          docker pull registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
 
-      - name: Get latest tag from destination image
-        id: uds_package_image_tag
-        run: |
-          DESTINATION="${{ matrix.image.destination }}"
-          UDS_PACKAGE_IMAGE_TAG=$(uds zarf tools registry ls ${DESTINATION} 2>/dev/null | grep -v "ERR\|GET\|NAME_UNKNOWN" | sort -V | tail -n 1)
-          echo "Latest destination tag: ${UDS_PACKAGE_IMAGE_TAG}"
-          echo "uds_package_image_tag=${UDS_PACKAGE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+      # - name: Environment setup
+      #   run: |
+      #       uds run actions:setup-environment \
+      #       --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
+      #       --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \
+      #       --set GH_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
+      #   shell: bash
 
-      - name: Check digest and retag if needed
-        run: |
-          SOURCE="${{ matrix.image.source }}"
-          DESTINATION="${{ matrix.image.destination }}"
-          CHAINGUARD_APK_TAG="${{ steps.chainguard_apk_version.outputs.chainguard_apk_tag }}"
-          UDS_PACKAGE_IMAGE_TAG="${{ steps.uds_package_image_tag.outputs.uds_package_image_tag }}"
+      # - name: Get version from Chainguard image SBOM
+      #   id: chainguard_apk_version
+      #   run: |
+      #     CHAINGUARD_APK_TAG=$(uds zarf tools sbom scan ${{ matrix.image.source }} -o spdx-json | \
+      #       jq -r '.packages[] | select(.name == "${{ matrix.image.sbom_package }}" and .supplier == "Person: wolfi") | .versionInfo')
+      #     echo "SBOM Wolfi APK version: ${CHAINGUARD_APK_TAG}"
+      #     echo "chainguard_apk_tag=${CHAINGUARD_APK_TAG}" >> "$GITHUB_OUTPUT"
 
-          if [ "${CHAINGUARD_APK_TAG}" = "${UDS_PACKAGE_IMAGE_TAG}" ]; then
-            SOURCE_DIGEST=$(uds zarf tools registry digest ${SOURCE})
-            echo "Source digest: ${SOURCE_DIGEST}"
+      # - name: Get latest tag from destination image
+      #   id: uds_package_image_tag
+      #   run: |
+      #     DESTINATION="${{ matrix.image.destination }}"
+      #     UDS_PACKAGE_IMAGE_TAG=$(uds zarf tools registry ls ${DESTINATION} 2>/dev/null | grep -v "ERR\|GET\|NAME_UNKNOWN" | sort -V | tail -n 1)
+      #     echo "Latest destination tag: ${UDS_PACKAGE_IMAGE_TAG}"
+      #     echo "uds_package_image_tag=${UDS_PACKAGE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 
-            DESTINATION_DIGEST=$(uds zarf tools registry digest ${DESTINATION}:${UDS_PACKAGE_IMAGE_TAG})
-            echo "Destination digest: ${DESTINATION_DIGEST}"
+      # - name: Check digest and retag if needed
+      #   run: |
+      #     SOURCE="${{ matrix.image.source }}"
+      #     DESTINATION="${{ matrix.image.destination }}"
+      #     CHAINGUARD_APK_TAG="${{ steps.chainguard_apk_version.outputs.chainguard_apk_tag }}"
+      #     UDS_PACKAGE_IMAGE_TAG="${{ steps.uds_package_image_tag.outputs.uds_package_image_tag }}"
 
-            if [ "${SOURCE_DIGEST}" = "${DESTINATION_DIGEST}" ]; then
-              echo "Tag ${CHAINGUARD_APK_TAG} exists with matching digest, no change needed"
-            else
-              echo "Tag ${CHAINGUARD_APK_TAG} exists with new digest, repushing image"
-              uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
-              echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
-            fi
-          else
-            echo "New Chainguard APK version ${CHAINGUARD_APK_TAG} detected, copying image"
-            uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
-            echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
-          fi
+      #     if [ "${CHAINGUARD_APK_TAG}" = "${UDS_PACKAGE_IMAGE_TAG}" ]; then
+      #       SOURCE_DIGEST=$(uds zarf tools registry digest ${SOURCE})
+      #       echo "Source digest: ${SOURCE_DIGEST}"
+
+      #       DESTINATION_DIGEST=$(uds zarf tools registry digest ${DESTINATION}:${UDS_PACKAGE_IMAGE_TAG})
+      #       echo "Destination digest: ${DESTINATION_DIGEST}"
+
+      #       if [ "${SOURCE_DIGEST}" = "${DESTINATION_DIGEST}" ]; then
+      #         echo "Tag ${CHAINGUARD_APK_TAG} exists with matching digest, no change needed"
+      #       else
+      #         echo "Tag ${CHAINGUARD_APK_TAG} exists with new digest, repushing image"
+      #         uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
+      #         echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
+      #       fi
+      #     else
+      #       echo "New Chainguard APK version ${CHAINGUARD_APK_TAG} detected, copying image"
+      #       uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
+      #       echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
+      #     fi

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -3,7 +3,7 @@
 
 name: Retag Minio Images
       # Scans Chainguard sboms for wolfi apk version for latest image tag
-      # This is done with on cgr and registry1
+      # This is done with chainguard and registry1 (chainguard) images
       # Checks latest tag for ghcr.io/uds-packages/minio-operator/container/[registry1]/chainguard/minio[client]
       # CHAINGUARD_APK_TAG == uds_package_image_tag + same digest → no change
       # CHAINGUARD_APK_TAG == uds_package_image_tag + different digest → repush with same tag (Chainguard rebuilt image)

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -3,6 +3,7 @@
 
 name: Retag Minio Images
       # Scans Chainguard sboms for wolfi apk version for latest image tag
+      # This is done with on cgr and registry1
       # Pulls the latest tag for ghcr.io/uds-packages/minio-operator/container/chainguard-minio[client]
       # CHAINGUARD_APK_TAG == uds_package_image_tag + same digest → no change
       # CHAINGUARD_APK_TAG == uds_package_image_tag + different digest → repush with same tag (Chainguard rebuilt image)
@@ -19,6 +20,9 @@ on:
 jobs:
   retag:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     permissions:
       contents: read
       packages: write
@@ -47,7 +51,6 @@ jobs:
 
       - name: Environment setup
         run: |
-            echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ secrets.GITHUB_TOKEN }}\"}\"" >> "GITHUB_ENV"
             uds run actions:setup-environment \
             --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
             --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Environment setup
         run: |
+            echo "MARU_AUTH=\"{\"raw.githubusercontent.com\": \"${{ secrets.GITHUB_TOKEN }}\"}\"" >> "GITHUB_ENV"
             uds run actions:setup-environment \
             --set REGISTRY1_USERNAME="${{ secrets.IRON_BANK_ROBOT_USERNAME }}" \
             --set REGISTRY1_PASSWORD="${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" \

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -4,18 +4,14 @@
 name: Retag Minio Images
       # Scans Chainguard sboms for wolfi apk version for latest image tag
       # This is done with on cgr and registry1
-      # Pulls the latest tag for ghcr.io/uds-packages/minio-operator/container/chainguard-minio[client]
+      # Checks latest tag for ghcr.io/uds-packages/minio-operator/container/[registry1]/chainguard/minio[client]
       # CHAINGUARD_APK_TAG == uds_package_image_tag + same digest → no change
       # CHAINGUARD_APK_TAG == uds_package_image_tag + different digest → repush with same tag (Chainguard rebuilt image)
       # CHAINGUARD_APK_TAG != uds_package_image_tag → copy chainguard:latest/retag and push
 
 on:
-  push:
-    branches:
-      - retag-registry1-latest
   schedule:
     - cron: '0 14 * * *' # daily at 8 AM Central
-  workflow_dispatch: # manual trigger for testing
 
 jobs:
   retag:
@@ -32,12 +28,12 @@ jobs:
           - source: cgr.dev/chainguard/minio:latest
             destination: ghcr.io/uds-packages/minio-operator/container/chainguard/minio
             sbom_package: minio
-          # - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
-          #   destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio-client
-          #   sbom_package: mc
-          # - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio:latest
-          #   destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio
-          #   sbom_package: minio
+          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
+            destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio-client
+            sbom_package: mc
+          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio:latest
+            destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio
+            sbom_package: minio
 
     steps:
       - name: Checkout repository
@@ -47,7 +43,7 @@ jobs:
         uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
         with:
           # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
-          version: v0.30.0
+          version: v0.30.1
 
       - name: Environment setup
         run: |

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -12,7 +12,7 @@ name: Retag Minio Images
 on:
   push:
     branches:
-      - retag-registry1-latest  
+      - retag-registry1-latest
   schedule:
     - cron: '0 14 * * *' # daily at 8 AM Central
   workflow_dispatch: # manual trigger for testing
@@ -20,9 +20,6 @@ on:
 jobs:
   retag:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     permissions:
       contents: read
       packages: write
@@ -43,6 +40,9 @@ jobs:
             sbom_package: minio
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
       - name: Install UDS CLI
         uses: defenseunicorns/setup-uds@ab842abcad1f7a3305c2538e3dd1950d0daacfa5 # v1.0.1
         with:

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -33,10 +33,10 @@ jobs:
           #   destination: ghcr.io/uds-packages/minio-operator/container/chainguard-minio
           #   sbom_package: minio
           - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
-            destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio-client
+            destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio-client
             sbom_package: mc
-          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
-            destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio
+          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio:latest
+            destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio
             sbom_package: minio
 
     steps:
@@ -48,14 +48,6 @@ jobs:
         with:
           # renovate: datasource=github-tags depName=defenseunicorns/uds-cli versioning=semver
           version: v0.30.0
-
-      - name: Login to registry1
-        run: |
-          echo "${{ secrets.IRON_BANK_ROBOT_PASSWORD }}" | docker login -u "${{ secrets.IRON_BANK_ROBOT_USERNAME }}" --password-stdin registry1.dso.mil
-
-      - name: Test docker pull
-        run: |
-          docker pull registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
 
       - name: Environment setup
         run: |

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -26,18 +26,18 @@ jobs:
     strategy:
       matrix:
         image:
-          # - source: cgr.dev/chainguard/minio-client:latest
-          #   destination: ghcr.io/uds-packages/minio-operator/container/chainguard-minio-client
-          #   sbom_package: mc
-          # - source: cgr.dev/chainguard/minio:latest
-          #   destination: ghcr.io/uds-packages/minio-operator/container/chainguard-minio
-          #   sbom_package: minio
-          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
-            destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio-client
+          - source: cgr.dev/chainguard/minio-client:latest
+            destination: ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client
             sbom_package: mc
-          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio:latest
-            destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio
+          - source: cgr.dev/chainguard/minio:latest
+            destination: ghcr.io/uds-packages/minio-operator/container/chainguard/minio
             sbom_package: minio
+          # - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
+          #   destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio-client
+          #   sbom_package: mc
+          # - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio:latest
+          #   destination: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio
+          #   sbom_package: minio
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/retag-chainguard-minio.yaml
+++ b/.github/workflows/retag-chainguard-minio.yaml
@@ -32,10 +32,10 @@ jobs:
           # - source: cgr.dev/chainguard/minio:latest
           #   destination: ghcr.io/uds-packages/minio-operator/container/chainguard-minio
           #   sbom_package: minio
-          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
-            destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio-client
-            sbom_package: mc
-          - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio:latest
+          # - source: registry1.dso.mil/chainguard/cgr.dev/chainguard/minio-client:latest
+          #   destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio-client
+          #   sbom_package: mc
+          - source: registry1.dso.mil/ironbank/opensource/minio/minio:RELEASE.2025-10-15T17-29-55Z
             destination: ghcr.io/uds-packages/minio-operator/container/registry1-chainguard-minio
             sbom_package: minio
 
@@ -65,37 +65,37 @@ jobs:
           echo "SBOM Wolfi APK version: ${CHAINGUARD_APK_TAG}"
           echo "chainguard_apk_tag=${CHAINGUARD_APK_TAG}" >> "$GITHUB_OUTPUT"
 
-      - name: Get latest tag from destination image
-        id: uds_package_image_tag
-        run: |
-          DESTINATION="${{ matrix.image.destination }}"
-          UDS_PACKAGE_IMAGE_TAG=$(uds zarf tools registry ls ${DESTINATION} 2>/dev/null | grep -v "ERR\|GET\|NAME_UNKNOWN" | sort -V | tail -n 1)
-          echo "Latest destination tag: ${UDS_PACKAGE_IMAGE_TAG}"
-          echo "uds_package_image_tag=${UDS_PACKAGE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+      # - name: Get latest tag from destination image
+      #   id: uds_package_image_tag
+      #   run: |
+      #     DESTINATION="${{ matrix.image.destination }}"
+      #     UDS_PACKAGE_IMAGE_TAG=$(uds zarf tools registry ls ${DESTINATION} 2>/dev/null | grep -v "ERR\|GET\|NAME_UNKNOWN" | sort -V | tail -n 1)
+      #     echo "Latest destination tag: ${UDS_PACKAGE_IMAGE_TAG}"
+      #     echo "uds_package_image_tag=${UDS_PACKAGE_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 
-      - name: Check digest and retag if needed
-        run: |
-          SOURCE="${{ matrix.image.source }}"
-          DESTINATION="${{ matrix.image.destination }}"
-          CHAINGUARD_APK_TAG="${{ steps.chainguard_apk_version.outputs.chainguard_apk_tag }}"
-          UDS_PACKAGE_IMAGE_TAG="${{ steps.uds_package_image_tag.outputs.uds_package_image_tag }}"
+      # - name: Check digest and retag if needed
+      #   run: |
+      #     SOURCE="${{ matrix.image.source }}"
+      #     DESTINATION="${{ matrix.image.destination }}"
+      #     CHAINGUARD_APK_TAG="${{ steps.chainguard_apk_version.outputs.chainguard_apk_tag }}"
+      #     UDS_PACKAGE_IMAGE_TAG="${{ steps.uds_package_image_tag.outputs.uds_package_image_tag }}"
 
-          if [ "${CHAINGUARD_APK_TAG}" = "${UDS_PACKAGE_IMAGE_TAG}" ]; then
-            SOURCE_DIGEST=$(uds zarf tools registry digest ${SOURCE})
-            echo "Source digest: ${SOURCE_DIGEST}"
+      #     if [ "${CHAINGUARD_APK_TAG}" = "${UDS_PACKAGE_IMAGE_TAG}" ]; then
+      #       SOURCE_DIGEST=$(uds zarf tools registry digest ${SOURCE})
+      #       echo "Source digest: ${SOURCE_DIGEST}"
 
-            DESTINATION_DIGEST=$(uds zarf tools registry digest ${DESTINATION}:${UDS_PACKAGE_IMAGE_TAG})
-            echo "Destination digest: ${DESTINATION_DIGEST}"
+      #       DESTINATION_DIGEST=$(uds zarf tools registry digest ${DESTINATION}:${UDS_PACKAGE_IMAGE_TAG})
+      #       echo "Destination digest: ${DESTINATION_DIGEST}"
 
-            if [ "${SOURCE_DIGEST}" = "${DESTINATION_DIGEST}" ]; then
-              echo "Tag ${CHAINGUARD_APK_TAG} exists with matching digest, no change needed"
-            else
-              echo "Tag ${CHAINGUARD_APK_TAG} exists with new digest, repushing image"
-              uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
-              echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
-            fi
-          else
-            echo "New Chainguard APK version ${CHAINGUARD_APK_TAG} detected, copying image"
-            uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
-            echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
-          fi
+      #       if [ "${SOURCE_DIGEST}" = "${DESTINATION_DIGEST}" ]; then
+      #         echo "Tag ${CHAINGUARD_APK_TAG} exists with matching digest, no change needed"
+      #       else
+      #         echo "Tag ${CHAINGUARD_APK_TAG} exists with new digest, repushing image"
+      #         uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
+      #         echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
+      #       fi
+      #     else
+      #       echo "New Chainguard APK version ${CHAINGUARD_APK_TAG} detected, copying image"
+      #       uds zarf tools registry copy ${SOURCE} ${DESTINATION}:${CHAINGUARD_APK_TAG}
+      #       echo "Pushed ${DESTINATION}:${CHAINGUARD_APK_TAG}"
+      #     fi


### PR DESCRIPTION
## Description

Registry1 Chainguard images: pull and repush with the tag for the version to the MiniO GHCR repo. We will then have an immutable tagged version for Minio.

Testing Confirmations:
- New retagging workflow successful run [here](https://github.com/uds-packages/minio-operator/actions/runs/24093826501/job/70286967565).
- Retagged images successfully passed in CI, [this workflow](https://github.com/uds-packages/minio-operator/actions/runs/24096961160).

**Note**: updated ghcr path to a more conventional structure. The minio/minio-client image names and tags will be the same between registry1 and upstream. GCHR path for:
- Registry1 (cgr images): `ghcr.io/uds-packages/minio-operator/container/registry1/chainguard`
- Chainguard: `ghcr.io/uds-packages/minio-operator/container/chainguard`

## Related Issue
https://linear.app/defense-unicorns/issue/FDRY-75/registry1-retagging-from-latest

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/minio-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
