### PR TITLE
feat: release for chainguard minio

### DIFF
--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=quay.io/minio/operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 7.1.1-uds.8
+    version: 7.1.1-uds.19
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/minio/operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 7.1.1-uds.18
+    version: 7.1.1-uds.19
   - name: unicorn
     # renovate-uds: datasource=docker depName=quay.io/rfcurated/minio/operator
     version: 7.1.1-uds.18


### PR DESCRIPTION
## Description

Trigger release for image updates to Chainguard for `minio` and `minio-client`, flavors upstream and registry1.

## Related Issue
https://linear.app/defense-unicorns/issue/FDRY-73/release-package-and-announce


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/uds-packages/minio-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
