### PR TITLE
chore: manual package deps

### DIFF
--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=quay.io/minio/operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 7.1.1-uds.20
+    version: 7.1.1-uds.21
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/minio/operator extractVersion=^v?(?<version>\d+\.\d+\.\d+)$
-    version: 7.1.1-uds.21
+    version: 7.1.1-uds.22
   - name: unicorn
     # renovate-uds: datasource=docker depName=quay.io/rfcurated/minio/operator
     version: 7.1.1-uds.19

--- a/tests/minio/mc-cli-policy.yaml
+++ b/tests/minio/mc-cli-policy.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: minio-client
-          image: ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r8
+          image: ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r10
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/tests/minio/mc-cli-test.yaml
+++ b/tests/minio/mc-cli-test.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: minio-client
-          image: ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r8
+          image: ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r10
           command: ["/bin/bash", "-c"]
           args:
             - |

--- a/tests/minio/zarf.yaml
+++ b/tests/minio/zarf.yaml
@@ -25,4 +25,4 @@ components:
           - mc-cli-test.yaml
           - mc-cli-policy.yaml
     images:
-      - ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r8
+      - ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r10

--- a/values/registry1-config-values.yaml
+++ b/values/registry1-config-values.yaml
@@ -1,5 +1,5 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-mcImage: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio-client:0.20250813.083541-r8
+mcImage: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio-client:0.20250813.083541-r10
 mcShell: /bin/bash

--- a/values/registry1-tenant-values.yaml
+++ b/values/registry1-tenant-values.yaml
@@ -5,5 +5,5 @@ tenant:
   image:
     repository: ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio
     # renovate: datasource=docker depName=ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio versioning=semver
-    tag: 0.20260330.001845-r2
+    tag: 0.20260410.215259-r1
     pullPolicy: IfNotPresent

--- a/values/upstream-config-values.yaml
+++ b/values/upstream-config-values.yaml
@@ -1,5 +1,5 @@
 # Copyright 2024 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
-mcImage: ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r8
+mcImage: ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r10
 mcShell: /bin/bash

--- a/values/upstream-tenant-values.yaml
+++ b/values/upstream-tenant-values.yaml
@@ -5,4 +5,4 @@ tenant:
   image:
     repository: ghcr.io/uds-packages/minio-operator/container/chainguard/minio
     # renovate: datasource=docker depName=ghcr.io/uds-packages/minio-operator/container/chainguard/minio versioning=semver
-    tag: 0.20260330.001845-r2
+    tag: 0.20260410.215259-r1

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -40,8 +40,8 @@ components:
     images:
       - quay.io/minio/operator:v7.1.1
       - quay.io/minio/operator-sidecar:v7.1.0
-      - ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r8
-      - ghcr.io/uds-packages/minio-operator/container/chainguard/minio:0.20260330.001845-r2
+      - ghcr.io/uds-packages/minio-operator/container/chainguard/minio-client:0.20250813.083541-r10
+      - ghcr.io/uds-packages/minio-operator/container/chainguard/minio:0.20260410.215259-r1
 
   - name: minio-operator
     required: true
@@ -64,8 +64,8 @@ components:
     images:
       - registry1.dso.mil/ironbank/opensource/minio/operator:v7.1.1
       - registry1.dso.mil/ironbank/opensource/minio/operator-sidecar:v7.1.0
-      - ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio-client:0.20250813.083541-r8
-      - ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio:0.20260330.001845-r2
+      - ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio-client:0.20250813.083541-r10
+      - ghcr.io/uds-packages/minio-operator/container/registry1/chainguard/minio:0.20260410.215259-r1
   - name: minio-operator
     required: true
     import:


### PR DESCRIPTION
## Description

- manual package deps, working to get renovate tracking package deps
- disabled (in GitHub UI) `auto update` workflow - as the retagging does daily image digest comparison with new tag. Need to discuss path forward.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/uds-packages/minio-operator/blob/main/CONTRIBUTING.md#developer-workflow) followed
