### PR TITLE
feat: expose package configuration via Zarf Values

### DIFF
--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -19,6 +19,12 @@ components:
           - name: TENANT
             path: name
             description: The name of the tenant
+        values:
+          - sourcePath: .uds-minio-config
+            targetPath: .
+            excludePaths:
+              - .uds-minio-config.mcImage
+              - .uds-minio-config.mcShell
       - name: minio-operator
         version: v7.1.1
         url: https://github.com/minio/operator.git
@@ -26,6 +32,15 @@ components:
         namespace: minio-operator
         valuesFiles:
           - ../values/common-values.yaml
+        values:
+          - sourcePath: .minio-operator
+            targetPath: .
+            excludePaths:
+              - .minio-operator.operator.image
+              - .minio-operator.operator.sidecarImage
+              - .minio-operator.operator.imagePullSecrets
+              - .minio-operator.operator.securityContext
+              - .minio-operator.operator.containerSecurityContext
       - name: minio-tenant
         version: v7.1.1
         url: https://github.com/minio/operator.git
@@ -37,6 +52,12 @@ components:
           - name: TENANT
             path: tenant.name
             description: The name of the tenant
+        values:
+          - sourcePath: .minio-tenant
+            targetPath: .
+            excludePaths:
+              - .minio-tenant.tenant.image
+              - .minio-tenant.tenant.imagePullSecret
     actions:
       onDeploy:
         after:

--- a/zarf-values.schema.json
+++ b/zarf-values.schema.json
@@ -1,0 +1,431 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "minio-operator": {
+      "properties": {
+        "operator": {
+          "properties": {
+            "additionalLabels": {
+              "properties": {},
+              "type": "object"
+            },
+            "affinity": {
+              "properties": {
+                "podAntiAffinity": {
+                  "properties": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "env": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "initContainers": {
+              "type": "array"
+            },
+            "nodeSelector": {
+              "properties": {},
+              "type": "object"
+            },
+            "priorityClassName": {
+              "type": "string"
+            },
+            "replicaCount": {
+              "type": "number"
+            },
+            "resources": {
+              "properties": {
+                "requests": {
+                  "properties": {
+                    "cpu": {
+                      "type": "string"
+                    },
+                    "ephemeral-storage": {
+                      "type": "string"
+                    },
+                    "memory": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "runtimeClassName": {
+              "type": "string"
+            },
+            "serviceAccountAnnotations": {
+              "type": "array"
+            },
+            "tolerations": {
+              "type": "array"
+            },
+            "topologySpreadConstraints": {
+              "type": "array"
+            },
+            "volumeMounts": {
+              "type": "array"
+            },
+            "volumes": {
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "minio-tenant": {
+      "properties": {
+        "ingress": {
+          "properties": {
+            "api": {
+              "properties": {
+                "annotations": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "host": {
+                  "type": "string"
+                },
+                "ingressClassName": {
+                  "type": "string"
+                },
+                "labels": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "pathType": {
+                  "type": "string"
+                },
+                "tls": {
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "console": {
+              "properties": {
+                "annotations": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "host": {
+                  "type": "string"
+                },
+                "ingressClassName": {
+                  "type": "string"
+                },
+                "labels": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "pathType": {
+                  "type": "string"
+                },
+                "tls": {
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "tenant": {
+          "properties": {
+            "additionalVolumeMounts": {
+              "type": "array"
+            },
+            "additionalVolumes": {
+              "type": "array"
+            },
+            "buckets": {
+              "type": "array"
+            },
+            "certificate": {
+              "properties": {
+                "certConfig": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "externalCaCertSecret": {
+                  "type": "array"
+                },
+                "externalCertSecret": {
+                  "type": "array"
+                },
+                "requestAutoCert": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "configSecret": {
+              "properties": {
+                "accessKey": {
+                  "type": "string"
+                },
+                "existingSecret": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "secretKey": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "configuration": {
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "env": {
+              "type": "array"
+            },
+            "exposeServices": {
+              "properties": {},
+              "type": "object"
+            },
+            "features": {
+              "properties": {
+                "bucketDNS": {
+                  "type": "boolean"
+                },
+                "domains": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "enableSFTP": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "initContainers": {
+              "type": "array"
+            },
+            "lifecycle": {
+              "properties": {},
+              "type": "object"
+            },
+            "liveness": {
+              "properties": {},
+              "type": "object"
+            },
+            "logging": {
+              "properties": {},
+              "type": "object"
+            },
+            "metrics": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "port": {
+                  "type": "number"
+                },
+                "protocol": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "mountPath": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "podManagementPolicy": {
+              "type": "string"
+            },
+            "pools": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "servers": {
+                    "type": "number"
+                  },
+                  "size": {
+                    "type": "string"
+                  },
+                  "volumesPerServer": {
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "poolsMetadata": {
+              "properties": {
+                "annotations": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "labels": {
+                  "properties": {},
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "priorityClassName": {
+              "type": "string"
+            },
+            "prometheusOperator": {
+              "type": "boolean"
+            },
+            "readiness": {
+              "properties": {},
+              "type": "object"
+            },
+            "scheduler": {
+              "properties": {},
+              "type": "object"
+            },
+            "serviceAccountName": {
+              "type": "string"
+            },
+            "serviceMetadata": {
+              "properties": {},
+              "type": "object"
+            },
+            "startup": {
+              "properties": {},
+              "type": "object"
+            },
+            "subPath": {
+              "type": "string"
+            },
+            "users": {
+              "type": "array"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "uds-minio-config": {
+      "properties": {
+        "additionalNetworkAllow": {
+          "type": "array"
+        },
+        "ambient": {
+          "type": "boolean"
+        },
+        "apps": {
+          "type": "array"
+        },
+        "console": {
+          "properties": {
+            "gateway": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "domain": {
+          "type": "string"
+        },
+        "identityOpenidClientSecret": {
+          "type": "string"
+        },
+        "identityOpenidConfigUrl": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "rootPassword": {
+          "type": "string"
+        },
+        "rootUser": {
+          "type": "string"
+        },
+        "sso": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/zarf-values.yaml
+++ b/zarf-values.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# Zarf Values defaults for the minio-operator package. Each top-level key maps onto one chart
+# (see common/zarf.yaml). Defaults intentionally stay empty so chart and flavor values files
+# remain the single source of truth; deployers override only what they need.
+uds-minio-config: {}
+minio-operator: {}
+minio-tenant: {}

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -19,6 +19,11 @@ variables:
   - name: DOMAIN
     default: uds.dev
 
+values:
+  files:
+    - zarf-values.yaml
+  schema: zarf-values.schema.json
+
 components:
   - name: minio-operator
     required: true


### PR DESCRIPTION
## Description

Adds a [Zarf Values](https://docs.defenseunicorns.com/core/concepts/configuration--packaging/package-values/) passthrough to this package, so deployers (bundles, and Fleet Command per-group values) can configure the charts directly without bundle overrides.

Follows the shape validated on [uds-packages/cert-manager#247](https://github.com/uds-packages/cert-manager/pull/247) and [uds-packages/jaeger#72](https://github.com/uds-packages/jaeger/pull/72).

## Changes

- `common/zarf.yaml`: each chart maps a top-level values key onto its Helm values root, per the [uds-common nginx reference](https://github.com/defenseunicorns/uds-common/blob/main/zarf.yaml):
  - `uds-minio-config` → config chart (exposes `apps` bucket/user wiring, `domain`, `console`, `sso`, `rootUser`/`rootPassword`, `additionalNetworkAllow`), with `mcImage` and `mcShell` excluded since the minio-client image and its shell are pinned per flavor
  - `minio-operator` → upstream operator chart, with `excludePaths` guarding package integrity: `operator.image`, `operator.sidecarImage`, `operator.imagePullSecrets`, `operator.securityContext`, `operator.containerSecurityContext`
  - `minio-tenant` → upstream tenant chart, with `excludePaths` guarding `tenant.image` and `tenant.imagePullSecret`; tenant/bucket configuration (`pools`, `buckets`, `users`, `configSecret`, `features`) stays exposed
- `zarf.yaml`: top-level `values` block referencing `zarf-values.yaml` + `zarf-values.schema.json`
- `zarf-values.yaml`: intentionally empty per-chart keys; chart defaults and flavor values files stay the single source of truth
- `zarf-values.schema.json`: generated with `zarf dev generate-schema . -f upstream -u` (zarf v0.81.0). Mappings live in `common/` so the schema is identical across flavors.

The existing `TENANT` and `DOMAIN` Zarf variables (including the chart-level `TENANT` variables on the config and tenant charts) are left untouched.

## Validation

- Schema generation resolves all three charts; verified all guarded keys are absent from the schema and `pools`, `buckets`, `users`, `configSecret`, resources, and the config chart `apps` wiring remain exposed
- `zarf dev lint . -f upstream` passes with no errors (only pre-existing unpinned image digest warnings)
- Full package create/deploy left to CI

## Notes for review

- Per-pool `securityContext`/`containerSecurityContext` live inside `tenant.pools` array entries, which `excludePaths` cannot address (paths only reach object keys). Pools stay exposed because pool sizing is the primary deployer surface for this package.
- The operator chart ships its CRDs unconditionally in templates, so there is no CRD toggle to guard.
